### PR TITLE
KWD-3: Moved Dependency versions into gradle.properties. Library Version Upgrades

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,21 +33,21 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile "com.android.support:appcompat-v7:$SUPPORT_LIBS_VERSION"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
-    compile 'com.squareup.picasso:picasso:2.5.2'
-    compile 'com.squareup.retrofit2:retrofit:2.3.0'
-    compile 'com.squareup.retrofit2:converter-moshi:2.3.0'
-    compile 'com.squareup.retrofit2:adapter-rxjava2:2.3.0'
-    compile "io.reactivex.rxjava2:rxjava:2.1.0"
-    compile "io.reactivex.rxjava2:rxandroid:2.0.1"
-    compile 'com.google.android.gms:play-services-location:11.0.0'
-    compile 'com.github.stephanenicolas.toothpick:toothpick-runtime:1.0.7'
-    compile 'com.github.stephanenicolas.toothpick:smoothie:1.0.7'
-    kapt 'com.github.stephanenicolas.toothpick:toothpick-compiler:1.0.7'
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.easymock:easymock:3.4'
-    testCompile 'com.github.stephanenicolas.toothpick:toothpick-testing:1.0.7'
+    compile "com.squareup.picasso:picasso:$PICASSO_VERSION"
+    compile "com.squareup.retrofit2:retrofit:$RETROFIT_VERSION"
+    compile "com.squareup.retrofit2:converter-moshi:$RETROFIT_VERSION"
+    compile "com.squareup.retrofit2:adapter-rxjava2:$RETROFIT_VERSION"
+    compile "io.reactivex.rxjava2:rxjava:$RX_JAVA_VERSION"
+    compile "io.reactivex.rxjava2:rxandroid:$RX_ANDROID_VERSION"
+    compile "com.google.android.gms:play-services-location:$PLAY_SERVICES_VERSION"
+    compile "com.github.stephanenicolas.toothpick:toothpick-runtime:$TOOTHPICK_VERSION"
+    compile "com.github.stephanenicolas.toothpick:smoothie:$TOOTHPICK_VERSION"
+    kapt "com.github.stephanenicolas.toothpick:toothpick-compiler:$TOOTHPICK_VERSION"
+    testCompile "com.github.stephanenicolas.toothpick:toothpick-testing:$TOOTHPICK_VERSION"
+    testCompile "junit:junit:$JUNIT_VERSION"
+    testCompile "org.easymock:easymock:$EASYMOCK_VERSION"
 }
 
 kapt {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,17 +1,11 @@
-# Project-wide Gradle settings.
-
-# IDE (e.g. Android Studio) users:
-# Gradle settings configured through the IDE *will override*
-# any settings specified in this file.
-
-# For more details on how to configure your build environment visit
-# http://www.gradle.org/docs/current/userguide/build_environment.html
-
-# Specifies the JVM arguments used for the daemon process.
-# The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
 
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+PLAY_SERVICES_VERSION=11.0.2
+SUPPORT_LIBS_VERSION=25.3.1
+TOOTHPICK_VERSION=1.0.8
+EASYMOCK_VERSION=3.4
+JUNIT_VERSION=4.12
+RX_ANDROID_VERSION=2.0.1
+RX_JAVA_VERSION=2.1.0
+RETROFIT_VERSION=2.3.0
+PICASSO_VERSION=2.5.2


### PR DESCRIPTION
Libraries updated : 
- Play Services to 11.0.2
- ToothPick to 1.0.8
- Support Libs to 25.3.1

_Moving to a gradle.properties file and referencing within the `build.gradle` provides a cleaner less error prone method of managing library versions_

Addresses : 
- https://github.com/ekamp/KotlinWeather/issues/3
- https://github.com/ekamp/KotlinWeather/issues/2